### PR TITLE
Add pr cleanup to github actions

### DIFF
--- a/.github/workflows/artifactsCleanUp.yml
+++ b/.github/workflows/artifactsCleanUp.yml
@@ -1,0 +1,13 @@
+name: PR cleanup
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  delete_pr_artifacts:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: stefanluptak/delete-old-pr-artifacts@v1
+        with:
+          workflow_filename: ci.yaml


### PR DESCRIPTION
The GitHub storage is full, so we need a GitHub Action that automatically deletes the previous artifacts of closed pull requests.
The pull request should be approved so that we can test if it works.